### PR TITLE
Done at 07:15 MSK 14.05.22

### DIFF
--- a/cloud-application/application/src/main/java/com/buzas/cloud/application/model/DownloadMessage.java
+++ b/cloud-application/application/src/main/java/com/buzas/cloud/application/model/DownloadMessage.java
@@ -8,8 +8,8 @@ public class DownloadMessage extends AbstractMessage{
 
     private String name;
 
-    public DownloadMessage(Path path) throws IOException {
-        name = path.getFileName().toString();
+    public DownloadMessage(String name) throws IOException {
+        this.name = name;
     }
 
     public String getName() {

--- a/cloud-application/application/src/main/resources/main.fxml
+++ b/cloud-application/application/src/main/resources/main.fxml
@@ -39,7 +39,7 @@
             <TableView fx:id="userTable" onContextMenuRequested="#contextMenuOverUser" prefHeight="442.0" prefWidth="300.0">
               <columns>
                 <TableColumn fx:id="userFileNames" prefWidth="75.0" text="Name" />
-                <TableColumn fx:id="userFileSizes" prefWidth="75.0" text="Size" />
+                <TableColumn fx:id="userFileSizes" prefWidth="75.0" text="Size(bytes)" />
               </columns>
                <columnResizePolicy>
                   <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
@@ -56,7 +56,7 @@
             <TableView fx:id="serverTable" onContextMenuRequested="#contextMenuOverServer" prefHeight="442.0" prefWidth="300.0">
               <columns>
                 <TableColumn fx:id="serverFileNames" prefWidth="75.0" text="Name" />
-                <TableColumn fx:id="serverFileSizes" prefWidth="75.0" text="Size" />
+                <TableColumn fx:id="serverFileSizes" prefWidth="75.0" text="Size(bytes)" />
               </columns>
                <columnResizePolicy>
                   <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />

--- a/cloud-server/server-app/src/main/java/handlers/FileHandler.java
+++ b/cloud-server/server-app/src/main/java/handlers/FileHandler.java
@@ -32,7 +32,7 @@ public class FileHandler extends SimpleChannelInboundHandler<AbstractMessage> {
             ctx.write(new ListMessage(serverDirectory));
         }
         if (message instanceof DownloadMessage downloadMessage){
-            Path downloadedFilePath = Path.of(serverDirectory.resolve(downloadMessage.getName()).toString());
+            Path downloadedFilePath = serverDirectory.resolve(downloadMessage.getName());
             if (!Files.isDirectory(downloadedFilePath)){
                 if (Files.exists(downloadedFilePath)) {
                     ctx.write(new DeliverMessage(downloadedFilePath));
@@ -49,7 +49,10 @@ public class FileHandler extends SimpleChannelInboundHandler<AbstractMessage> {
         }
         if (message instanceof DirectoryRequestMessage requestMessage){
             Path targetPath = serverDirectory.resolve(requestMessage.getName());
-            if (Files.isDirectory(targetPath)){
+            if (requestMessage.getName().equals("..")){
+                serverDirectory = Path.of("cloud-server/cloudFiles");
+                ctx.write(new DirectoryAnswerMessage(true, serverDirectory));
+            } else if (Files.isDirectory(targetPath)){
                 serverDirectory = targetPath;
                 ctx.write(new DirectoryAnswerMessage(true, Path.of(requestMessage.getName())));
             } else {

--- a/cloud-server/server-core/src/main/java/com/buzas/cloud/application/model/DownloadMessage.java
+++ b/cloud-server/server-core/src/main/java/com/buzas/cloud/application/model/DownloadMessage.java
@@ -1,21 +1,18 @@
 package com.buzas.cloud.application.model;
 
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 
 public class DownloadMessage extends AbstractMessage{
 
     private String name;
 
-    public DownloadMessage(Path path) throws IOException {
-        name = path.getFileName().toString();
+    public DownloadMessage(String name) throws IOException {
+        this.name = name;
     }
 
     public String getName() {
         return name;
     }
-
 
     @Override
     public MessageType getMessageType() {


### PR DESCRIPTION
Починил моменты, которые работали не так, как надо: перенес создание контекстных меню в инициализацию, убрал зависимость отправляемых сервером данных от Nio на стороне клиента - теперь используют только Netty. Так и не смог решить проблему с отображением всплывающих окон при работе с серверными файлами, потому к заглушкам добавил отображение для пользователя в rightNameplate, где обычно отображается название директории. Заблокировал возможность переходить дальше основной директории, чтобы клиент не смог залезть в файлы сервера, которые видеть не должен. Взамен переход на шаг назад теперь и возвращает в основную директорию. Не уверен, что знаю, как решить проблему и вернуть возможность шага назад при большом количестве папок. Полагаю, решу эту проблему одновременно с добавлением создания папок